### PR TITLE
Update .NET SDK version to 10.0.x and modify LocalStaticApp implementation for improved routing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use .NET SDK
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Build project
       run: dotnet build -c Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use .NET SDK
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: NuGet login
       uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
@@ -30,7 +30,7 @@ jobs:
     - name: Pack NuGet Packages
       run: |
         dotnet pack src/WebJobs.Extensions.HttpApi/WebJobs.Extensions.HttpApi.csproj -c Release -o ./dist -p:Version=${{ steps.setup_version.outputs.VERSION }}
-        dotnet pack src/Functions.Worker.Extensions.HttpApi/Functions.Worker.Extensions.HttpApi.csproj -c Release -o ./dist -p:Version=${{ steps.setup_version.outputs.VERSION }}
+        dotnet pack src/Worker.Extensions.HttpApi/Worker.Extensions.HttpApi.csproj -c Release -o ./dist -p:Version=${{ steps.setup_version.outputs.VERSION }}
 
     - name: Publish NuGet Packages
       run: dotnet nuget push dist/*.nupkg -k ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/samples/IsolatedSample/IsolatedSample.csproj
+++ b/samples/IsolatedSample/IsolatedSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/WebsiteSample/StaticWebsite.cs
+++ b/samples/WebsiteSample/StaticWebsite.cs
@@ -12,10 +12,9 @@ public class StaticWebsite(IHttpContextAccessor httpContextAccessor) : HttpFunct
     [FunctionName(nameof(StaticWebsite))]
     public IActionResult Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", "put", "delete", "options", "head", "patch", Route = "{*path}")]
-        HttpRequest req)
+        HttpRequest req,
+        string path)
     {
-        //return RemoteStaticApp("https://ststaticwebsiteproxy.z11.web.core.windows.net", fallbackExclude: $"^/_nuxt/.*");
-
-        return LocalStaticApp(fallbackPath: "200.html", fallbackExclude: $"^/_nuxt/.*");
+        return LocalStaticApp(path, fallbackPath: "200.html", fallbackExcludePattern: "^/_nuxt/.*");
     }
 }

--- a/src/Shared/Core/HttpFunctionImpl.cs
+++ b/src/Shared/Core/HttpFunctionImpl.cs
@@ -208,8 +208,8 @@ public abstract class HttpFunctionImpl(IHttpContextAccessor httpContextAccessor)
         return new ProxyResult(backendUri) { BeforeSend = beforeSend, AfterSend = afterSend };
     }
 
-    protected LocalStaticAppResult LocalStaticApp(string defaultFile = "index.html", string fallbackPath = "404.html", string? fallbackExcludePattern = null)
-        => new() { DefaultFile = defaultFile, FallbackPath = fallbackPath, FallbackExcludePattern = fallbackExcludePattern };
+    protected LocalStaticAppResult LocalStaticApp(string requestPath, string defaultFile = "index.html", string fallbackPath = "404.html", string? fallbackExcludePattern = null)
+        => new() { RequestPath = requestPath, DefaultFile = defaultFile, FallbackPath = fallbackPath, FallbackExcludePattern = fallbackExcludePattern };
 
     #endregion
 

--- a/src/Shared/Core/LocalStaticAppResult.cs
+++ b/src/Shared/Core/LocalStaticAppResult.cs
@@ -9,6 +9,8 @@ namespace Azure.WebJobs.Extensions.HttpApi.Core;
 /// </summary>
 public class LocalStaticAppResult : IActionResult
 {
+    public required string RequestPath { get; set; }
+
     public string DefaultFile { get; set; } = "index.html";
 
     public string FallbackPath { get; set; } = "404.html";

--- a/src/Shared/Core/LocalStaticAppResultExecutor.cs
+++ b/src/Shared/Core/LocalStaticAppResultExecutor.cs
@@ -19,14 +19,7 @@ internal sealed class LocalStaticAppResultExecutor : IActionResultExecutor<Local
 
     public async Task ExecuteAsync(ActionContext context, LocalStaticAppResult result)
     {
-        var routeValues = context.RouteData.Values;
-
-        if (routeValues.Count == 0)
-        {
-            throw new InvalidOperationException("No route values found. The LocalStaticApp result requires a route with at least one parameter (e.g., '{*path}').");
-        }
-
-        var virtualPath = $"/{routeValues.First().Value}";
+        var virtualPath = $"/{result.RequestPath}";
 
         var contents = s_fileProvider.GetDirectoryContents(virtualPath);
 

--- a/src/WebJobs.Extensions.HttpApi/WebJobs.Extensions.HttpApi.csproj
+++ b/src/WebJobs.Extensions.HttpApi/WebJobs.Extensions.HttpApi.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces several updates to support .NET 10, refactors the static website serving logic to improve routing and path handling, and makes minor dependency and packaging corrections. The most important changes are grouped below.

**.NET 10 Upgrade**

* Workflow files (`.github/workflows/build.yml`, `.github/workflows/publish.yml`) and the sample project (`samples/IsolatedSample/IsolatedSample.csproj`) are updated to use .NET 10 instead of .NET 9 or 8. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L18-R18) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L18-R18) [[3]](diffhunk://#diff-6214d514565989a5ae073fed9427ec95033c469ffcf3c5c2f93bf08b479686cdL3-R3)

**Static Website Routing Refactor**

* The `StaticWebsite` function now accepts the route parameter `path` and passes it to `LocalStaticApp`, which improves how static files are resolved for requests.
* The `LocalStaticApp` method and `LocalStaticAppResult` class are updated to accept and require a `requestPath`, ensuring the request path is explicitly provided and used in static file resolution. [[1]](diffhunk://#diff-fcdd9e077af73b0c1b1c32e62164041bd973cab9ca999cee0e9fa626e0f994feL211-R212) [[2]](diffhunk://#diff-5970dca5d26466cb347d5c3b263b7362005424a6466702222b63d1e12e9e7264R12-R13)
* The `LocalStaticAppResultExecutor` now uses the `RequestPath` property directly instead of extracting it from route values, simplifying and clarifying path handling.

**Packaging and Dependency Adjustments**

* The NuGet packaging workflow is corrected to reference the proper worker extension project (`Worker.Extensions.HttpApi.csproj`), and the `Microsoft.Azure.WebJobs.Extensions.Http` package is downgraded from 3.3.0 to 3.2.1. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L33-R33) [[2]](diffhunk://#diff-5a24f8786419e060aa0c60d043bd67ccf26be74da8ac415f1591e038cb1960abL27-R27)